### PR TITLE
Update Leaflet SRI hashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,12 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Market Map</title>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2atRU8YzJH8TfN7HtNe0zWMuQ74pqwLJ8m60y0=" crossorigin="anonymous" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin="anonymous"
+  />
   <style>
     :root {
       color-scheme: light dark;
@@ -17418,7 +17423,11 @@
     ]
   </script>
 
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kG9h3L7xk2EXs3BMpnhbXoYsJh8mF+AAZ0Z0w=" crossorigin="anonymous"></script>
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+    crossorigin="anonymous"
+  ></script>
   <script>
     const data = JSON.parse(document.getElementById('marketmap-data').textContent);
     const regionColors = {"Mid-Atlantic Region": "#f94144", "Mountain Region": "#f3722c", "Multi-Family Region": "#f8961e", "North Central Region": "#f9844a", "Northeast Region": "#f9c74f", "Northwest Region": "#90be6d", "Pacific Region": "#43aa8b", "South Central Region": "#577590", "Southeast Region": "#277da1", "TX Windows Region": "#9d4edd", "": "#8d99ae"};


### PR DESCRIPTION
## Summary
- update the Leaflet CDN link and script tags to use the current SHA-256 SRI digests
- keep the crossorigin attributes while reformatting the tags for readability

## Testing
- python -m http.server 8000
- manual verification in browser (Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68e65b79acb883298ab368811c8c57c9